### PR TITLE
Add basic CI configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,57 @@
+# Copyright (c) 2023 ETH Zurich
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+name: Linux
+
+on:
+  push:
+    branches:
+      - main
+      - release**
+  pull_request:
+    branches:
+      - main
+      - release**
+
+jobs:
+  build:
+    name: linux
+    runs-on: ubuntu-latest
+
+    steps:
+    # Set up environment
+    - name: Update apt repositories for ccache
+      run: sudo apt update
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ccache-linux
+    - name: Install tools
+      run: sudo apt install -y cmake gcc ninja-build
+
+    # Install stdexec
+    - name: Check out stdexec
+      uses: actions/checkout@v3
+      with:
+        repository: NVIDIA/stdexec
+        ref: f4c9aff7aca8e811318785d4c9d581afe54a04a7
+        path: stdexec
+    - name: Install stdexec
+      working-directory: stdexec
+      run: |
+          cmake . -Bbuild -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          sudo cmake --build build --target install
+
+    # Build and test std-async-algorithms
+    - name: Check out std-async-algorithms
+      uses: actions/checkout@v3
+    - name: Configure std-async-algorithms
+      run: cmake . -Bbuild -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+    - name: Build std-async-algorithms
+      run: cmake --build build --target all
+    - name: Test std-async-algorithms
+      working-directory: build
+      run: ctest --output-on-failure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Check out std-async-algorithms
       uses: actions/checkout@v3
     - name: Configure std-async-algorithms
-      run: cmake . -Bbuild -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+      run: cmake . -Bbuild -GNinja -DSTD_ASYNC_ALGORITHMS_WITH_TESTS=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
     - name: Build std-async-algorithms
       run: cmake --build build --target all
     - name: Test std-async-algorithms

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,15 @@ add_library(std_async_algorithms INTERFACE)
 target_include_directories(std_async_algorithms INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(std_async_algorithms INTERFACE STDEXEC::stdexec)
 
-# Test executable
-add_executable(for_each tests/for_each.cpp)
-target_link_libraries(for_each PRIVATE std_async_algorithms $<TARGET_NAME_IF_EXISTS:pika::pika>)
-target_compile_definitions(for_each PRIVATE $<$<TARGET_EXISTS:pika::pika>:STD_ASYNC_ALGOS_HAVE_PIKA>)
+# Tests
+option(STD_ASYNC_ALGORITHMS_WITH_TESTS "Enable tests" OFF)
+
+if(STD_ASYNC_ALGORITHMS_WITH_TESTS)
+  enable_testing()
+  include(CTest)
+
+  add_executable(for_each_test tests/for_each.cpp)
+  target_link_libraries(for_each_test PRIVATE std_async_algorithms $<TARGET_NAME_IF_EXISTS:pika::pika>)
+  target_compile_definitions(for_each_test PRIVATE $<$<TARGET_EXISTS:pika::pika>:STD_ASYNC_ALGOS_HAVE_PIKA>)
+  add_test(NAME for_each COMMAND for_each_test)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,6 @@ cmake_minimum_required(VERSION 3.22)
 
 project(std-async-algorithms CXX)
 
-# TODO: This is missing from STDEXEC's config file.
-find_package(Threads REQUIRED)
 find_package(STDEXEC REQUIRED)
 find_package(pika)
 

--- a/include/stdalgos/detail/for_each.hpp
+++ b/include/stdalgos/detail/for_each.hpp
@@ -85,7 +85,7 @@ struct for_each_t {
                  F &&f) const {
     // TODO: Can with_execution_properties change the scheduler type?
     return stdexec::tag_invoke(
-        with_execution_properties(stdexec::get_completion_scheduler<stdexec::set_value_t>(sender),
+        with_execution_properties(stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(sender)),
                                   exec_properties),
         std::forward<Sender>(sender), std::forward<F>(f));
   }
@@ -116,7 +116,7 @@ struct for_each_t {
     // TODO: Should a (completion) scheduler be required?
     if constexpr (stdexec::__has_completion_scheduler<Sender, stdexec::set_value_t>) {
       stdexec::scheduler auto sched =
-          stdexec::get_completion_scheduler<stdexec::set_value_t>(sender);
+          stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(sender));
       return stdexec::let_value(
           std::forward<Sender>(sender),
           [f = std::forward<F>(f), sched = std::move(sched), exec_properties](auto &b, auto &e) {


### PR DESCRIPTION
Fixes #3.

Also updates the stdexec commit to the latest available at the moment. This also means getting the completion scheduler of a sender from its environment rather than directly from the sender.